### PR TITLE
Remove dependency on recommonmark

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,8 +47,7 @@ autosummary_generate = True
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
-source_suffix = ['.rst', '.md']
-source_parsers = {'.md': 'recommonmark.parser.CommonMarkParser'}
+source_suffix = ['.rst']
 
 # The master toctree document.
 master_doc = 'index'


### PR DESCRIPTION
Only needed for .md and we're sticking to .rst